### PR TITLE
#12 서재 상세 UI

### DIFF
--- a/src/components/ReadRecordInfo.tsx
+++ b/src/components/ReadRecordInfo.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { FaStar } from 'react-icons/fa'
+
+export default function ReadRecordInfo({
+    rate,
+    startDate,
+    endDate,
+}: {
+    rate: number
+    startDate: string
+    endDate: string
+}) {
+    const printStarScore = (cnt: number) => {
+        const arr = []
+        for (let i = 0; i < cnt; i += 1) {
+            arr.push(<FaStar />)
+        }
+
+        return arr
+    }
+    return (
+        <div className="flex flex-col gap-6 mt-4">
+            <div className="flex gap-12 items-center text-xl">
+                <span className="text-gray text-lg">평점</span>
+                <div className="flex gap-3 text-3xl text-[#FFE55B]">
+                    {printStarScore(rate)}
+                </div>
+            </div>
+            <div className="flex flex-col gap-2 text-xl">
+                <span className="text-gray text-lg">독서 기간</span>
+                <div className="grid grid-cols-2 px-6 py-4 bg-lightGray rounded-md">
+                    <div className="flex gap-10">
+                        <span className="text-primary font-bold">시작일</span>
+                        <p>{startDate}</p>
+                    </div>
+                    <div className="flex gap-10">
+                        <span className="text-primary font-bold">종료일</span>
+                        <p>{endDate}</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/components/ReadingRecordInfo.tsx
+++ b/src/components/ReadingRecordInfo.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+export default function ReadingRecordInfo({
+    page,
+    startDate,
+}: {
+    page: number
+    startDate: string
+}) {
+    return (
+        <div className="flex flex-col gap-6 mt-4">
+            <div className="flex gap-12 items-center text-xl">
+                <span className="text-gray text-lg">독서량</span>
+                <p className="flex gap-3 text-xl">{page}페이지</p>
+            </div>
+            <div className="flex flex-col gap-2 text-xl">
+                <span className="text-gray text-lg">독서 기간</span>
+                <div className="grid grid-cols-2 px-6 py-4 bg-lightGray rounded-md">
+                    <div className="flex gap-10">
+                        <span className="text-primary font-bold">시작일</span>
+                        <p>{startDate}</p>
+                    </div>
+                    <div className="flex gap-10">
+                        <span className="text-primary font-bold">종료일</span>
+                        <p>-</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/components/Record.tsx
+++ b/src/components/Record.tsx
@@ -1,0 +1,43 @@
+import { Chip } from '@mui/material'
+import React from 'react'
+import getFormattedDate from '../utils/getFormattedDate'
+
+interface RecordType {
+    recordId: number
+    tag: string | null
+    date: string
+    content: string
+    page: number | null
+}
+
+export default function Record({ value }: { value: RecordType }) {
+    return (
+        <div className="flex gap-4 p-4 border-b-[0.5px] border-gray">
+            <div className="flex flex-col gap-2 items-center">
+                {value.tag && (
+                    <Chip
+                        label={value.tag}
+                        sx={{
+                            backgroundColor: '#1E863B',
+                            color: 'white',
+                            fontWeight: 'bold',
+                            fontSize: '1rem',
+                        }}
+                    />
+                )}
+                {value.page && (
+                    <span className="text-lg font-bold">p. {value.page}</span>
+                )}
+            </div>
+            <div className="flex flex-col flex-1 justify-between min-h-20">
+                <p className="text-lg">{value.content}</p>
+                <div className="flex gap-4 justify-end text-gray text-sm">
+                    <span>{getFormattedDate(value.date)}</span>
+                    <button type="button" className="underline">
+                        삭제
+                    </button>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/components/WishRecordInfo.tsx
+++ b/src/components/WishRecordInfo.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+export default function WishRecordInfo({
+    expectation,
+}: {
+    expectation: string
+}) {
+    return (
+        <div className="flex flex-col gap-6 mt-4">
+            <div className="flex flex-col gap-2 text-xl">
+                <span className="text-gray text-lg">기대평</span>
+                <div className="grid grid-cols-2 px-6 py-4 bg-lightGray rounded-md">
+                    <p>{expectation}</p>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/pages/LibraryDetail.tsx
+++ b/src/pages/LibraryDetail.tsx
@@ -5,16 +5,20 @@ import Footer from '../layouts/Footer'
 import Wrapper from '../layouts/Wrapper'
 import SearchItem from '../components/SearchItem'
 import searchResult from '../data/SearchResult.json'
-import LibraryDetailInfo from '../components/LibraryDetailInfo'
+import ReadRecordInfo from '../components/ReadRecordInfo'
 import Record from '../components/Record'
+import ReadingRecordInfo from '../components/ReadingRecordInfo'
+import WishRecordInfo from '../components/WishRecordInfo'
+import { LibraryDetailType } from '../types/libraryType'
 
 export default function LibraryDetail() {
-    const dummyData = {
+    const dummyData: LibraryDetailType = {
+        status: 'wish',
         rate: 3,
         startDate: '2024-03-01',
         endDate: '2024-03-05',
-        pages: null,
-        expectation: null,
+        page: 100,
+        expectation: '짱 기대중',
         recordList: [
             {
                 recordId: 1,
@@ -66,7 +70,25 @@ export default function LibraryDetail() {
                     </ul>
                 </div>
                 <SearchItem searchResult={searchResult.documents[0]} />
-                <LibraryDetailInfo />
+                {dummyData.status === 'read' && (
+                    <ReadRecordInfo
+                        rate={dummyData.rate ?? 0}
+                        startDate={dummyData.startDate ?? '없음'}
+                        endDate={dummyData.endDate ?? '없음'}
+                    />
+                )}
+                {dummyData.status === 'reading' && (
+                    <ReadingRecordInfo
+                        page={dummyData.page ?? 0}
+                        startDate={dummyData.startDate ?? '없음'}
+                    />
+                )}
+                {dummyData.status === 'wish' && (
+                    <WishRecordInfo
+                        expectation={dummyData.expectation ?? '없음'}
+                    />
+                )}
+
                 <div className="mt-20">
                     <p className="text-lg">
                         총{' '}

--- a/src/pages/LibraryDetail.tsx
+++ b/src/pages/LibraryDetail.tsx
@@ -1,0 +1,88 @@
+import React from 'react'
+import { Chip } from '@mui/material'
+import Header from '../layouts/Header'
+import Footer from '../layouts/Footer'
+import Wrapper from '../layouts/Wrapper'
+import SearchItem from '../components/SearchItem'
+import searchResult from '../data/SearchResult.json'
+import LibraryDetailInfo from '../components/LibraryDetailInfo'
+import Record from '../components/Record'
+
+export default function LibraryDetail() {
+    const dummyData = {
+        rate: 3,
+        startDate: '2024-03-01',
+        endDate: '2024-03-05',
+        pages: null,
+        expectation: null,
+        recordList: [
+            {
+                recordId: 1,
+                tag: 'review',
+                date: '2024-03-01T09:00:00',
+                content: '오늘은 어쩌구를 읽었다',
+                page: 54,
+            },
+            {
+                recordId: 2,
+                tag: 'review',
+                date: '2024-03-01T09:00:00',
+                content: '오늘은 어쩌구를 읽었다',
+                page: 54,
+            },
+        ],
+    }
+    return (
+        <div>
+            <Header />
+            <Wrapper>
+                <div className="flex justify-between mb-6">
+                    <Chip
+                        label="읽은 책"
+                        color="success"
+                        sx={{
+                            fontSize: '1.2rem',
+                            height: '2.1rem',
+                            paddingX: '0.2rem',
+                        }}
+                    />
+                    <ul className="flex gap-4">
+                        <li>
+                            <button
+                                type="button"
+                                className="text-gray underline"
+                            >
+                                수정
+                            </button>
+                        </li>
+                        <li>
+                            <button
+                                type="button"
+                                className="text-gray underline"
+                            >
+                                삭제
+                            </button>
+                        </li>
+                    </ul>
+                </div>
+                <SearchItem searchResult={searchResult.documents[0]} />
+                <LibraryDetailInfo />
+                <div className="mt-20">
+                    <p className="text-lg">
+                        총{' '}
+                        <span className="font-bold text-primary">
+                            {dummyData.recordList.length}
+                        </span>
+                        개의 기록이 있습니다.
+                    </p>
+                    <div>
+                        {dummyData.recordList.map((record) => (
+                            <Record value={record} key={record.recordId} />
+                        ))}
+                    </div>
+                </div>
+            </Wrapper>
+            <Footer />
+        </div>
+    )
+}

--- a/src/pages/LibraryDetail.tsx
+++ b/src/pages/LibraryDetail.tsx
@@ -10,6 +10,7 @@ import Record from '../components/Record'
 import ReadingRecordInfo from '../components/ReadingRecordInfo'
 import WishRecordInfo from '../components/WishRecordInfo'
 import { LibraryDetailType } from '../types/libraryType'
+import { statusKo } from '../types/bookType'
 
 export default function LibraryDetail() {
     const dummyData: LibraryDetailType = {
@@ -42,7 +43,7 @@ export default function LibraryDetail() {
             <Wrapper>
                 <div className="flex justify-between mb-6">
                     <Chip
-                        label="읽은 책"
+                        label={statusKo[dummyData.status]}
                         color="success"
                         sx={{
                             fontSize: '1.2rem',

--- a/src/types/bookType.ts
+++ b/src/types/bookType.ts
@@ -4,5 +4,11 @@ const status = {
     rading: 'reading',
     wish: 'wish',
 } as const
-
 export type Status = (typeof status)[keyof typeof status]
+
+// 책 담기 상태 한국어
+export const statusKo = {
+    read: '읽은 책',
+    reading: '읽고 있는 책',
+    wish: '읽고 싶은 책',
+}

--- a/src/types/bookType.ts
+++ b/src/types/bookType.ts
@@ -1,0 +1,8 @@
+// 책 담기 상태(읽은 책, 읽고 있는 책, 읽고 싶은 책)
+const status = {
+    read: 'read',
+    rading: 'reading',
+    wish: 'wish',
+} as const
+
+export type Status = (typeof status)[keyof typeof status]

--- a/src/types/libraryType.ts
+++ b/src/types/libraryType.ts
@@ -1,0 +1,31 @@
+import { Status } from './bookType'
+
+// Record의 태그(감상평, 인용, 줄거리, 의문점)
+const tag = {
+    review: 'review',
+    quote: 'quote',
+    summary: 'summary',
+    question: 'question',
+} as const
+
+export type Tag = (typeof tag)[keyof typeof tag]
+
+// 서재 상세 데이터 타입
+export interface LibraryDetailType {
+    status: Status
+    rate: number | null
+    startDate: string | null
+    endDate: string | null
+    page: number | null
+    expectation: string | null
+    recordList: RecordType[]
+}
+
+// 기록 데이터 타입
+export interface RecordType {
+    recordId: number
+    page: number | null
+    tag: Tag
+    date: string
+    content: string
+}


### PR DESCRIPTION
### 변경사항
- 서재 상세페이지
- 기록 컴포넌트 생성
- 책 담은 정보 컴포넌트 생성(예: 시작일, 종료일, 읽은 페이지 수 등)
  - 책 담은 정보를 상태별로 나타내도록 함
 
### 특이사항
- 책과 서재 데이터 타입을 types 폴더에 공통 interface로 분리

close #12 