### PR TITLE
#19 도서검색 데이터 연결

### DIFF
--- a/src/components/SearchItem.tsx
+++ b/src/components/SearchItem.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { Link } from 'react-router-dom'
 import getFormattedDate from '../utils/getFormattedDate'
 import getFormattedIsbn from '../utils/getFormattedIsbn'
@@ -24,11 +24,6 @@ export default function SearchItem({
 }: {
     searchResult: SearchResultType
 }) {
-    const [isbn, setIsbn] = useState('')
-    useEffect(() => {
-        setIsbn(getFormattedIsbn(searchResult.isbn))
-    }, [])
-
     return (
         <div className="w-full flex gap-4 pb-4 border-b-[0.5px] border-lightGray">
             {/* SECTION - 이미지 */}
@@ -40,7 +35,7 @@ export default function SearchItem({
             {/* SECTION - 도서 정보 */}
             <div className="flex flex-col gap-1">
                 <Link
-                    to={`/search/${isbn}`}
+                    to={`/search/${getFormattedIsbn(searchResult.isbn)}`}
                     className="text-xl font-bold hover:underline"
                 >
                     {searchResult.title}

--- a/src/components/SearchItem.tsx
+++ b/src/components/SearchItem.tsx
@@ -2,27 +2,12 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import getFormattedDate from '../utils/getFormattedDate'
 import getFormattedIsbn from '../utils/getFormattedIsbn'
-
-interface SearchResultType {
-    title: string
-    authors: string[]
-    translators: string[]
-    publisher: string
-    datetime: string
-    contents: string
-    isbn: string
-    thumbnail: string
-    // 아래는 사용 x
-    url: string
-    price: number
-    sale_price: number
-    status: string
-}
+import { searchDocumentType } from '../types/searchResultType'
 
 export default function SearchItem({
     searchResult,
 }: {
-    searchResult: SearchResultType
+    searchResult: searchDocumentType
 }) {
     return (
         <div className="w-full flex gap-4 pb-4 border-b-[0.5px] border-lightGray">

--- a/src/components/SearchItem.tsx
+++ b/src/components/SearchItem.tsx
@@ -1,5 +1,7 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import getFormattedDate from '../utils/getFormattedDate'
+import getFormattedIsbn from '../utils/getFormattedIsbn'
 
 interface SearchResultType {
     title: string
@@ -22,6 +24,11 @@ export default function SearchItem({
 }: {
     searchResult: SearchResultType
 }) {
+    const [isbn, setIsbn] = useState('')
+    useEffect(() => {
+        setIsbn(getFormattedIsbn(searchResult.isbn))
+    }, [])
+
     return (
         <div className="w-full flex gap-4 pb-4 border-b-[0.5px] border-lightGray">
             {/* SECTION - 이미지 */}
@@ -32,9 +39,12 @@ export default function SearchItem({
             />
             {/* SECTION - 도서 정보 */}
             <div className="flex flex-col gap-1">
-                <a href="#test" className="text-xl font-bold hover:underline">
+                <Link
+                    to={`/search/${isbn}`}
+                    className="text-xl font-bold hover:underline"
+                >
                     {searchResult.title}
-                </a>
+                </Link>
                 <div className="flex gap-2">
                     <ul className="flex gap-2">
                         <span>저자: </span>

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { IoIosSearch } from 'react-icons/io'
 import Logo from '../components/Logo'
 
@@ -23,11 +23,17 @@ export default function Header() {
     return (
         <header className="flex justify-center w-full bg-primary">
             <div className="flex flex-row justify-between p-3 w-[90rem]">
-                <Logo />
+                <Link to="/">
+                    <Logo />
+                </Link>
                 <div className="flex flex-row justify-between gap-4">
                     <ul className="flex flex-row items-center gap-4 text-lg text-white">
-                        <li>서재</li>
-                        <li>통계</li>
+                        <li>
+                            <Link to="/library">서재</Link>
+                        </li>
+                        <li>
+                            <Link to="/statistics">통계</Link>
+                        </li>
                     </ul>
                     <form className="flex items-center px-4 py-0 rounded-3xl bg-white">
                         <input

--- a/src/pages/BookDetail.tsx
+++ b/src/pages/BookDetail.tsx
@@ -1,12 +1,27 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { FaBookmark } from 'react-icons/fa'
+import { useParams } from 'react-router-dom'
 import Wrapper from '../layouts/Wrapper'
 import AddBookModal from '../components/AddBookModal'
 import Header from '../layouts/Header'
 import Footer from '../layouts/Footer'
+import getSearchBook from '../services/searchBook'
+import { searchDocumentType } from '../types/searchResultType'
+import getFormattedDate from '../utils/getFormattedDate'
 
 export default function BookDetail() {
+    const { isbn } = useParams()
     const [isOpenModal, setIsOpenModal] = useState<boolean>(false)
+    const [searchDocument, setSearchDocument] = useState<searchDocumentType>()
+
+    useEffect(() => {
+        if (isbn !== undefined) {
+            getSearchBook(isbn).then((result) =>
+                setSearchDocument(result.documents[0])
+            )
+        }
+    })
+
     return (
         <>
             {isOpenModal && <AddBookModal setIsOpenModal={setIsOpenModal} />}
@@ -15,53 +30,44 @@ export default function BookDetail() {
                 <div className="flex gap-8">
                     {/* NOTE 예시 이미지 */}
                     <img
-                        src="https://contents.kyobobook.co.kr/sih/fit-in/458x0/pdt/9788998441012.jpg"
-                        alt="도서 이미지"
+                        src={searchDocument?.thumbnail}
+                        alt={`${searchDocument?.title} 도서 이미지`}
                         className="w-96 h-fit"
                     />
                     <div className="flex flex-col gap-12 w-full">
                         <div className="flex flex-col gap-3 text-xl">
                             <h1 className="text-4xl">
-                                도서 제목이 이렇게나 길어지면 어떻게 보여질까요?
-                                한번 확인해보겠습니다
+                                {searchDocument?.title}
                             </h1>
                             <div className="flex gap-4">
                                 <ul className="flex gap-2">
                                     <span>저자: </span>
+                                    {/* eslint-disable react/no-array-index-key */}
+                                    {searchDocument?.authors.map(
+                                        (author, index) => (
+                                            <li key={index}>{author}</li>
+                                        )
+                                    )}
                                 </ul>
                                 <ul className="flex gap-2">
                                     <span>번역: </span>
+                                    {/* eslint-disable react/no-array-index-key */}
+                                    {searchDocument?.translators.map(
+                                        (translator, index) => (
+                                            <li key={index}>{translator}</li>
+                                        )
+                                    )}
                                 </ul>
                             </div>
                             <div className="flex gap-4">
-                                <p>출판사</p>
-                                <p>출판 날짜</p>
+                                <p>{searchDocument?.publisher}</p>
+                                <p>
+                                    {getFormattedDate(
+                                        searchDocument?.datetime ?? ''
+                                    )}
+                                </p>
                             </div>
-                            <p>
-                                도서 설명이 이렇게나 길어지면 어떻게 보여질까요?
-                                한번 확인해보겠습니다도서 설명이 이렇게나
-                                길어지면 어떻게 보여질까요? 한번
-                                확인해보겠습니다도서 설명이 이렇게나 길어지면
-                                어떻게 보여질까요? 한번 확인해보겠습니다도서
-                                설명이 이렇게나 길어지면 어떻게 보여질까요? 한번
-                                확인해보겠습니다도서 설명이 이렇게나 길어지면
-                                어떻게 보여질까요? 한번 확인해보겠습니다도서
-                                설명이 이렇게나 길어지면 어떻게 보여질까요? 한번
-                                확인해보겠습니다도서 설명이 이렇게나 길어지면
-                                어떻게 보여질까요? 한번 확인해보겠습니다도서
-                                설명이 이렇게나 길어지면 어떻게 보여질까요? 한번
-                                확인해보겠습니다도서 설명이 이렇게나 길어지면
-                                어떻게 보여질까요? 한번 확인해보겠습니다도서
-                                설명이 이렇게나 길어지면 어떻게 보여질까요? 한번
-                                확인해보겠습니다도서 설명이 이렇게나 길어지면
-                                어떻게 보여질까요? 한번 확인해보겠습니다도서
-                                설명이 이렇게나 길어지면 어떻게 보여질까요? 한번
-                                확인해보겠습니다도서 설명이 이렇게나 길어지면
-                                어떻게 보여질까요? 한번 확인해보겠습니다도서
-                                설명이 이렇게나 길어지면 어떻게 보여질까요? 한번
-                                확인해보겠습니다도서 설명이 이렇게나 길어지면
-                                어떻게 보여질까요? 한번 확인해보겠습니다
-                            </p>
+                            <p>{searchDocument?.contents}</p>
                         </div>
                         <div className="flex flex-col gap-2 w-fit">
                             <p className="text-xl">

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Pagination } from '@mui/material'
+import { Link } from 'react-router-dom'
 import Header from '../layouts/Header'
 import Footer from '../layouts/Footer'
 import Wrapper from '../layouts/Wrapper'
@@ -10,51 +11,61 @@ export default function Library() {
             id: 1,
             thumbnail:
                 'https://contents.kyobobook.co.kr/sih/fit-in/458x0/pdt/9791189782900.jpg',
+            isbn: '1235',
         },
         {
             id: 2,
             thumbnail:
                 'https://contents.kyobobook.co.kr/sih/fit-in/458x0/pdt/9791189782900.jpg',
+            isbn: '1235',
         },
         {
             id: 3,
             thumbnail:
                 'https://contents.kyobobook.co.kr/sih/fit-in/458x0/pdt/9791189782900.jpg',
+            isbn: '1235',
         },
         {
             id: 4,
             thumbnail:
                 'https://contents.kyobobook.co.kr/sih/fit-in/458x0/pdt/9791189782900.jpg',
+            isbn: '1235',
         },
         {
             id: 5,
             thumbnail:
                 'https://contents.kyobobook.co.kr/sih/fit-in/458x0/pdt/9791189782900.jpg',
+            isbn: '1235',
         },
         {
             id: 6,
             thumbnail:
                 'https://contents.kyobobook.co.kr/sih/fit-in/458x0/pdt/9791189782900.jpg',
+            isbn: '1235',
         },
         {
             id: 7,
             thumbnail:
                 'https://contents.kyobobook.co.kr/sih/fit-in/458x0/pdt/9791189782900.jpg',
+            isbn: '1235',
         },
         {
             id: 8,
             thumbnail:
                 'https://contents.kyobobook.co.kr/sih/fit-in/458x0/pdt/9791189782900.jpg',
+            isbn: '1235',
         },
         {
             id: 9,
             thumbnail:
                 'https://contents.kyobobook.co.kr/sih/fit-in/458x0/pdt/9791189782900.jpg',
+            isbn: '1235',
         },
         {
             id: 10,
             thumbnail:
                 'https://contents.kyobobook.co.kr/sih/fit-in/458x0/pdt/9791189782900.jpg',
+            isbn: '1235',
         },
     ]
 
@@ -100,9 +111,9 @@ export default function Library() {
                 </ul>
                 <div className="grid grid-cols-5 gap-x-8 gap-y-16 mb-20">
                     {dummyBook.map((book) => (
-                        <button type="button" key={book.id}>
+                        <Link to={`/library/${book.isbn}`} key={book.id}>
                             <img src={book.thumbnail} alt="book thumbnail" />
-                        </button>
+                        </Link>
                     ))}
                 </div>
                 <Pagination count={10} size="large" className="w-fit mx-auto" />

--- a/src/pages/LibraryDetail.tsx
+++ b/src/pages/LibraryDetail.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Chip } from '@mui/material'
+import { useParams } from 'react-router-dom'
 import Header from '../layouts/Header'
 import Footer from '../layouts/Footer'
 import Wrapper from '../layouts/Wrapper'
 import SearchItem from '../components/SearchItem'
-import searchResult from '../data/SearchResult.json'
 import ReadRecordInfo from '../components/ReadRecordInfo'
 import Record from '../components/Record'
 import ReadingRecordInfo from '../components/ReadingRecordInfo'
@@ -12,7 +12,21 @@ import WishRecordInfo from '../components/WishRecordInfo'
 import { LibraryDetailType } from '../types/libraryType'
 import { statusKo } from '../types/bookType'
 
+import { searchDocumentType } from '../types/searchResultType'
+import getSearchBook from '../services/searchBook'
+
 export default function LibraryDetail() {
+    const { isbn } = useParams()
+    const [searchDocument, setSearchDocument] = useState<searchDocumentType>()
+
+    useEffect(() => {
+        if (isbn !== undefined) {
+            getSearchBook(isbn).then((result) =>
+                setSearchDocument(result.documents[0])
+            )
+        }
+    }, [])
+
     const dummyData: LibraryDetailType = {
         status: 'wish',
         rate: 3,
@@ -70,7 +84,7 @@ export default function LibraryDetail() {
                         </li>
                     </ul>
                 </div>
-                <SearchItem searchResult={searchResult.documents[0]} />
+                {searchDocument && <SearchItem searchResult={searchDocument} />}
                 {dummyData.status === 'read' && (
                     <ReadRecordInfo
                         rate={dummyData.rate ?? 0}

--- a/src/services/searchBook.ts
+++ b/src/services/searchBook.ts
@@ -1,25 +1,9 @@
 import axios from 'axios'
+import { searchDocumentType, searchMetaType } from '../types/searchResultType'
 
 export interface BookData {
-    meta: {
-        total_count: number
-        pageable_count: number
-        is_end: boolean
-    }
-    documents: {
-        title: string
-        contents: string
-        url: string
-        isbn: string
-        datetime: string
-        authors: string[]
-        publisher: string
-        translators: string[]
-        price: number
-        sale_price: number
-        thumbnail: string
-        status: string
-    }[]
+    meta: searchMetaType
+    documents: searchDocumentType[]
 }
 
 const getSearchBook = async (query: string): Promise<BookData> => {

--- a/src/types/searchResultType.ts
+++ b/src/types/searchResultType.ts
@@ -1,0 +1,20 @@
+export interface searchMetaType {
+    total_count: number
+    pageable_count: number
+    is_end: boolean
+}
+
+export interface searchDocumentType {
+    title: string
+    contents: string
+    url: string
+    isbn: string
+    datetime: string
+    authors: string[]
+    publisher: string
+    translators: string[]
+    price: number
+    sale_price: number
+    thumbnail: string
+    status: string
+}

--- a/src/utils/getFormattedIsbn.ts
+++ b/src/utils/getFormattedIsbn.ts
@@ -1,0 +1,11 @@
+const getFormattedIsbn = (isbn: string) => {
+    const arr = isbn.split(' ')
+
+    if (arr.length <= 0) {
+        return arr[0]
+    }
+
+    return arr[1]
+}
+
+export default getFormattedIsbn


### PR DESCRIPTION
### 변경 사항
- 헤더 네비게이션으로 변경
- 검색 목록 페이지, 검색 상세페이지, 서재 목록 페이지, 서재 상세페이지 isbn 검색으로 변경
- isbn 형식 변경 함수 생성(10자, 13자 모두 있을 경우 13자 선택)
- 도서 검색 결과 타입 분리(BookData -> searchDocumentType, searchMetaType)

close #19 
