### PR TITLE
#23 서재 삭제 기능 구현

### DIFF
--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -22,7 +22,7 @@ export default function Library() {
     const [status, setStatus] = useState<Status>('read')
     const [page, setPage] = useState<number>(1)
     const { data: isbns } = useQuery<LibraryType, Error>({
-        queryKey: ['library', status, page],
+        queryKey: ['library'],
         queryFn: () => getLibrary(status, page),
         staleTime: 1000 * 60,
     })

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -95,8 +95,12 @@ export default function Library() {
                 </ul>
                 {library.length > 0 ? (
                     <div className="grid grid-cols-5 gap-x-8 gap-y-16 mb-20">
-                        {library.map((book) => (
-                            <div className="flex flex-col gap-3">
+                        {/* eslint-disable react/no-array-index-key */}
+                        {library.map((book, libraryIndex) => (
+                            <div
+                                className="flex flex-col gap-3"
+                                key={libraryIndex}
+                            >
                                 <Link
                                     to={`/library/${book.isbn}`}
                                     key={book.isbn}

--- a/src/pages/LibraryDetail.tsx
+++ b/src/pages/LibraryDetail.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { Chip } from '@mui/material'
-import { useParams } from 'react-router-dom'
-import { useQuery } from '@tanstack/react-query'
+import { redirect, useParams } from 'react-router-dom'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
 import Header from '../layouts/Header'
 import Footer from '../layouts/Footer'
@@ -14,7 +14,7 @@ import WishRecordInfo from '../components/WishRecordInfo'
 import { statusKo } from '../types/bookType'
 import { searchDocumentType } from '../types/searchResultType'
 import getSearchBook from '../services/searchBook'
-import { getLibraryDetail } from '../services/library'
+import { deleteLibrary, getLibraryDetail } from '../services/library'
 import { LibraryDetailType } from '../types/libraryType'
 
 export default function LibraryDetail() {
@@ -35,6 +35,25 @@ export default function LibraryDetail() {
             queryFn: () => getLibraryDetail(isbn ?? ''),
         }
     )
+
+    const queryClient = useQueryClient()
+    const deleteLibraryMutation = useMutation({
+        mutationFn: () => deleteLibrary(isbn ?? ''),
+        onSuccess: () => {
+            queryClient.invalidateQueries({
+                queryKey: ['library'],
+            })
+
+            redirect('/library')
+        },
+        onError: (error) => {
+            console.log(error)
+        },
+    })
+
+    const handleDeleteLibrary = () => {
+        deleteLibraryMutation.mutate()
+    }
 
     return (
         <div>
@@ -67,6 +86,7 @@ export default function LibraryDetail() {
                             <button
                                 type="button"
                                 className="text-gray underline"
+                                onClick={handleDeleteLibrary}
                             >
                                 삭제
                             </button>

--- a/src/services/library.ts
+++ b/src/services/library.ts
@@ -58,3 +58,17 @@ export const getLibraryDetail = async (
 
     return libraryDetail
 }
+
+export const deleteLibrary = async (isbn: string) => {
+    const response = await axios.delete<responseType<null>>(
+        `${process.env.REACT_APP_API}/api/library`,
+        {
+            params: { isbn },
+        }
+    )
+
+    return response
+    // FIXME - 데이터 있을 때 테스트하고 정상 동작하면 변경하기
+    // if (response.data.success) return true
+    // return false
+}


### PR DESCRIPTION
### 변경사항
- 서재 삭제 함수(deleteLibrary) 추가
- 서재 삭제 버튼 클릭 시 해당 도서 삭제 기능 추가
- 서재 목록의 요소에 key 추가(Fix)

### 특이사항
- 서재 queryKey ['library']로 변경: queryKey에 status와 page도 함께 포함했는데 굳이 status와 Page를 나눠서 저장할 필요가 없고 mutation 구현에 어려움이 있어서 ['library']만 남김

close #23 