### PR TITLE
#26 검색 목록 페이지네이션

### DIFF
--- a/src/pages/BookDetail.tsx
+++ b/src/pages/BookDetail.tsx
@@ -16,7 +16,7 @@ export default function BookDetail() {
 
     useEffect(() => {
         if (isbn !== undefined) {
-            getSearchBook(isbn).then((result) =>
+            getSearchBook(isbn, 1).then((result) =>
                 setSearchDocument(result.documents[0])
             )
         }

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -35,7 +35,7 @@ export default function Library() {
             isbns.isbnList.forEach((isbn) => {
                 const formattedIsbn = getFormattedIsbn(isbn)
 
-                getSearchBook(formattedIsbn).then((result) => {
+                getSearchBook(formattedIsbn, 1).then((result) => {
                     const { title, authors, thumbnail } = result.documents[0]
                     libraryList.push({ isbn, title, authors, thumbnail })
                     console.log(libraryList)

--- a/src/pages/LibraryDetail.tsx
+++ b/src/pages/LibraryDetail.tsx
@@ -23,7 +23,7 @@ export default function LibraryDetail() {
 
     useEffect(() => {
         if (isbn !== undefined) {
-            getSearchBook(isbn).then((result) =>
+            getSearchBook(isbn, 1).then((result) =>
                 setSearchDocument(result.documents[0])
             )
         }

--- a/src/pages/SearchList.tsx
+++ b/src/pages/SearchList.tsx
@@ -8,21 +8,28 @@ import Footer from '../layouts/Footer'
 import getSearchBook, { BookData } from '../services/searchBook'
 import EmptyBookResult from '../components/EmptyBookResult'
 
+const SIZE = 10
 export default function SearchList() {
     const [searchResult, setSearchResult] = useState<BookData>()
     const [searchParams] = useSearchParams()
     const query = searchParams.get('query') ?? ''
+    const [page, setPage] = useState<number>(1)
 
     useEffect(() => {
         if (query !== '') {
-            getSearchBook(query).then((result) => setSearchResult(result))
+            getSearchBook(query, page).then((result) => setSearchResult(result))
         } else {
             setSearchResult({
                 meta: { total_count: 0, pageable_count: 0, is_end: true },
                 documents: [],
             })
         }
-    }, [query])
+    }, [query, page])
+
+    const countTotalPages = (cntItems: number) => {
+        const totalPage = Math.floor(cntItems / SIZE) + 1
+        return Math.min(totalPage, 100) // NOTE - 카카오 api 정책 상 page는 최대 100까지 가능
+    }
 
     return (
         <>
@@ -50,7 +57,12 @@ export default function SearchList() {
                 </div>
                 <div className="flex justify-center mt-10">
                     <Pagination
-                        count={searchResult && searchResult.meta.total_count}
+                        page={page}
+                        count={
+                            searchResult &&
+                            countTotalPages(searchResult.meta.pageable_count)
+                        }
+                        onChange={(e, value) => setPage(value)}
                         size="large"
                     />
                 </div>

--- a/src/pages/SearchList.tsx
+++ b/src/pages/SearchList.tsx
@@ -38,7 +38,7 @@ export default function SearchList() {
                 <p className="text-lg mb-6">
                     전체{' '}
                     <span className="font-bold text-primary">
-                        {searchResult && searchResult.meta.total_count}
+                        {searchResult && searchResult.meta.pageable_count}
                     </span>
                     건
                 </p>

--- a/src/services/searchBook.ts
+++ b/src/services/searchBook.ts
@@ -6,7 +6,10 @@ export interface BookData {
     documents: searchDocumentType[]
 }
 
-const getSearchBook = async (query: string): Promise<BookData> => {
+const getSearchBook = async (
+    query: string,
+    page: number
+): Promise<BookData> => {
     const response = await axios.get<BookData>(
         'https://dapi.kakao.com/v3/search/book',
         {
@@ -15,6 +18,7 @@ const getSearchBook = async (query: string): Promise<BookData> => {
             },
             params: {
                 query,
+                page,
             },
         }
     )


### PR DESCRIPTION
### 변경사항
- 검색 목록 페이지네이션 기능 추가
- 검색 결과 건수 total_count에서 pageable_count로 변경
  (사유: total_count는 노출가능하지 않은 문서도 포함하는 개수라서 적절하지 않음. pageable_count는 중복된 문서를 제외하고, 처음부터 요청 페이지까지의 노출 가능 문서 수임)

close #26 