### PR TITLE
#29 서재 상세페이지 담은책 오류 수정

### DIFF
--- a/src/components/AddBookModal.tsx
+++ b/src/components/AddBookModal.tsx
@@ -19,21 +19,21 @@ const bookTypes: bookType[] = [
     {
         id: 1,
         icon: <FcOk />,
-        type: 'read',
+        type: 'READ',
         title: '읽은 책',
         description: '다 읽었어요!',
     },
     {
         id: 2,
         icon: <FcReading />,
-        type: 'reading',
+        type: 'READING',
         title: '읽고 있는 책',
         description: '읽는 중이에요',
     },
     {
         id: 3,
         icon: <FcLike />,
-        type: 'wish',
+        type: 'WISH',
         title: '읽고 싶은 책',
         description: '앞으로 읽을 예정!',
     },
@@ -68,7 +68,7 @@ export default function AddBookModal({
     setIsOpenModal: React.Dispatch<React.SetStateAction<boolean>>
     isbn: string
 }) {
-    const [currentType, setCurrentType] = useState<Status>('read')
+    const [currentType, setCurrentType] = useState<Status>('READ')
     const [readInfo, setReadInfo] = useState<ReadInfoType>({
         startDate: todayStr(),
         endDate: todayStr(),
@@ -124,7 +124,7 @@ export default function AddBookModal({
         }
 
         switch (currentType) {
-            case 'read':
+            case 'READ':
                 if (
                     hasNullorEmpty(
                         readInfo.startDate,
@@ -147,7 +147,7 @@ export default function AddBookModal({
                     expectation: null,
                 })
                 break
-            case 'reading':
+            case 'READING':
                 if (hasNullorEmpty(readingInfo.startDate, readingInfo.page)) {
                     alert('읽고 있는 책 정보를 모두 입력해주세요!')
                     break
@@ -161,7 +161,7 @@ export default function AddBookModal({
                     expectation: null,
                 })
                 break
-            case 'wish':
+            case 'WISH':
                 if (hasNullorEmpty(wishInfo.expectation)) {
                     alert('읽고 싶은 책 정보를 모두 입력해주세요!')
                     break
@@ -207,9 +207,9 @@ export default function AddBookModal({
                     ))}
                 </div>
                 {/* eslint-disable no-nested-ternary */}
-                {currentType === 'read' ? (
+                {currentType === 'READ' ? (
                     <ReadBook readInfo={readInfo} setReadInfo={setReadInfo} />
-                ) : currentType === 'reading' ? (
+                ) : currentType === 'READING' ? (
                     <ReadingBook
                         readingInfo={readingInfo}
                         setReadingInfo={setReadingInfo}

--- a/src/components/ReadRecordInfo.tsx
+++ b/src/components/ReadRecordInfo.tsx
@@ -13,7 +13,7 @@ export default function ReadRecordInfo({
     const printStarScore = (cnt: number) => {
         const arr = []
         for (let i = 0; i < cnt; i += 1) {
-            arr.push(<FaStar />)
+            arr.push(<FaStar key={i} />)
         }
 
         return arr

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -19,7 +19,7 @@ interface LibraryListType {
 
 export default function Library() {
     const [library, setLibrary] = useState<LibraryListType[]>([])
-    const [status, setStatus] = useState<Status>('read')
+    const [status, setStatus] = useState<Status>('READ')
     const [page, setPage] = useState<number>(1)
     const { data: isbns } = useQuery<LibraryType, Error>({
         queryKey: ['library'],

--- a/src/pages/LibraryDetail.tsx
+++ b/src/pages/LibraryDetail.tsx
@@ -8,7 +8,7 @@ import Footer from '../layouts/Footer'
 import Wrapper from '../layouts/Wrapper'
 import SearchItem from '../components/SearchItem'
 import ReadRecordInfo from '../components/ReadRecordInfo'
-import Record from '../components/Record'
+// import Record from '../components/Record'
 import ReadingRecordInfo from '../components/ReadingRecordInfo'
 import WishRecordInfo from '../components/WishRecordInfo'
 import { statusKo } from '../types/bookType'
@@ -63,7 +63,7 @@ export default function LibraryDetail() {
                     <Chip
                         label={
                             libraryDetailData !== undefined
-                                ? statusKo[libraryDetailData?.status]
+                                ? statusKo[libraryDetailData.status]
                                 : '없음'
                         }
                         color="success"
@@ -94,20 +94,20 @@ export default function LibraryDetail() {
                     </ul>
                 </div>
                 {searchDocument && <SearchItem searchResult={searchDocument} />}
-                {libraryDetailData?.status === 'read' && (
+                {libraryDetailData?.status.toUpperCase() === 'READ' && (
                     <ReadRecordInfo
                         rate={libraryDetailData.rate ?? 0}
                         startDate={libraryDetailData.startDate ?? '없음'}
                         endDate={libraryDetailData.endDate ?? '없음'}
                     />
                 )}
-                {libraryDetailData?.status === 'reading' && (
+                {libraryDetailData?.status.toUpperCase() === 'READING' && (
                     <ReadingRecordInfo
                         page={libraryDetailData.page ?? 0}
                         startDate={libraryDetailData.startDate ?? '없음'}
                     />
                 )}
-                {libraryDetailData?.status === 'wish' && (
+                {libraryDetailData?.status.toUpperCase() === 'WISH' && (
                     <WishRecordInfo
                         expectation={libraryDetailData.expectation ?? '없음'}
                     />
@@ -122,9 +122,9 @@ export default function LibraryDetail() {
                         개의 기록이 있습니다.
                     </p>
                     <div>
-                        {libraryDetailData?.recordList.map((record) => (
+                        {/* {libraryDetailData?.recordList.map((record) => (
                             <Record value={record} key={record.recordId} />
-                        ))}
+                        ))} */}
                     </div>
                 </div>
             </Wrapper>

--- a/src/pages/LibraryDetail.tsx
+++ b/src/pages/LibraryDetail.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Chip } from '@mui/material'
+import { Chip, Pagination } from '@mui/material'
 import { redirect, useParams } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
@@ -14,12 +14,17 @@ import WishRecordInfo from '../components/WishRecordInfo'
 import { statusKo } from '../types/bookType'
 import { searchDocumentType } from '../types/searchResultType'
 import getSearchBook from '../services/searchBook'
-import { deleteLibrary, getLibraryDetail } from '../services/library'
-import { LibraryDetailType } from '../types/libraryType'
+import {
+    deleteLibrary,
+    getLibraryDetail,
+    getRecordList,
+} from '../services/library'
+import { LibraryDetailType, RecordListType } from '../types/libraryType'
 
 export default function LibraryDetail() {
     const { isbn } = useParams()
     const [searchDocument, setSearchDocument] = useState<searchDocumentType>()
+    const [recordPage, setRecordPage] = useState<number>(1)
 
     useEffect(() => {
         if (isbn !== undefined) {
@@ -35,6 +40,16 @@ export default function LibraryDetail() {
             queryFn: () => getLibraryDetail(isbn ?? ''),
         }
     )
+
+    const { data: recordData } = useQuery<RecordListType, AxiosError>({
+        queryKey: ['records'],
+        queryFn: () =>
+            getRecordList({ isbn: isbn || '', pageNumber: recordPage }),
+    })
+
+    useEffect(() => {
+        setRecordPage(recordData?.currentPage ?? 1)
+    }, [recordData])
 
     const queryClient = useQueryClient()
     const deleteLibraryMutation = useMutation({
@@ -117,7 +132,7 @@ export default function LibraryDetail() {
                     <p className="text-lg">
                         총{' '}
                         <span className="font-bold text-primary">
-                            {libraryDetailData?.recordList.length ?? 0}
+                            {recordData?.recordList?.length ?? 0}
                         </span>
                         개의 기록이 있습니다.
                     </p>
@@ -126,6 +141,13 @@ export default function LibraryDetail() {
                             <Record value={record} key={record.recordId} />
                         ))} */}
                     </div>
+                    <Pagination
+                        count={recordData?.totalPages}
+                        page={recordPage}
+                        onChange={(e, value) => setRecordPage(value)}
+                        size="large"
+                        className="w-fit mx-auto"
+                    />
                 </div>
             </Wrapper>
             <Footer />

--- a/src/pages/LibraryDetail.tsx
+++ b/src/pages/LibraryDetail.tsx
@@ -49,6 +49,7 @@ export default function LibraryDetail() {
 
     useEffect(() => {
         setRecordPage(recordData?.currentPage ?? 1)
+        console.log(libraryDetailData?.status)
     }, [recordData])
 
     const queryClient = useQueryClient()
@@ -77,7 +78,7 @@ export default function LibraryDetail() {
                 <div className="flex justify-between mb-6">
                     <Chip
                         label={
-                            libraryDetailData !== undefined
+                            libraryDetailData?.status !== undefined
                                 ? statusKo[libraryDetailData.status]
                                 : '없음'
                         }

--- a/src/pages/LibraryDetail.tsx
+++ b/src/pages/LibraryDetail.tsx
@@ -8,7 +8,7 @@ import Footer from '../layouts/Footer'
 import Wrapper from '../layouts/Wrapper'
 import SearchItem from '../components/SearchItem'
 import ReadRecordInfo from '../components/ReadRecordInfo'
-// import Record from '../components/Record'
+import Record from '../components/Record'
 import ReadingRecordInfo from '../components/ReadingRecordInfo'
 import WishRecordInfo from '../components/WishRecordInfo'
 import { statusKo } from '../types/bookType'
@@ -138,9 +138,9 @@ export default function LibraryDetail() {
                         개의 기록이 있습니다.
                     </p>
                     <div>
-                        {/* {libraryDetailData?.recordList.map((record) => (
+                        {recordData?.recordList?.map((record) => (
                             <Record value={record} key={record.recordId} />
-                        ))} */}
+                        ))}
                     </div>
                     <Pagination
                         count={recordData?.totalPages}

--- a/src/services/library.ts
+++ b/src/services/library.ts
@@ -36,7 +36,6 @@ export const getLibraryDetail = async (
             finishDate: string | null
             page: number | null
             expectation: string | null
-            recordList: RecordType[]
         }>
     >(`${process.env.REACT_APP_API}/api/library`, {
         params: {
@@ -53,7 +52,6 @@ export const getLibraryDetail = async (
         endDate: responseData.finishDate,
         page: responseData.page,
         expectation: responseData.expectation,
-        recordList: responseData.recordList,
     }
 
     return libraryDetail

--- a/src/services/library.ts
+++ b/src/services/library.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import { Status } from '../types/bookType'
 import responseType from '../types/responseType'
-import { LibraryDetailType, RecordType } from '../types/libraryType'
+import { LibraryDetailType, RecordListType } from '../types/libraryType'
 
 export interface LibraryType {
     totalPages: number
@@ -55,6 +55,26 @@ export const getLibraryDetail = async (
     }
 
     return libraryDetail
+}
+
+export const getRecordList = async ({
+    isbn,
+    pageNumber,
+}: {
+    isbn: string
+    pageNumber: number
+}) => {
+    const response = await axios.get<responseType<RecordListType>>(
+        `${process.env.REACT_APP_API}/api/record-list`,
+        {
+            params: {
+                isbn,
+                pageNumber,
+            },
+        }
+    )
+
+    return response.data.results
 }
 
 export const deleteLibrary = async (isbn: string) => {

--- a/src/services/library.ts
+++ b/src/services/library.ts
@@ -14,7 +14,7 @@ export const getLibrary = async (
     page: number
 ): Promise<LibraryType> => {
     const response = await axios.get<responseType<LibraryType>>(
-        `${process.env.REACT_APP_API}/api/library/${status}`,
+        `${process.env.REACT_APP_API}/api/library/${status.toLowerCase()}`,
         {
             params: {
                 pageNumber: page,

--- a/src/types/bookType.ts
+++ b/src/types/bookType.ts
@@ -1,14 +1,14 @@
 // 책 담기 상태(읽은 책, 읽고 있는 책, 읽고 싶은 책)
 export const statusEn = {
-    read: 'read',
-    rading: 'reading',
-    wish: 'wish',
+    READ: 'READ',
+    READING: 'READING',
+    WISH: 'WISH',
 } as const
 export type Status = (typeof statusEn)[keyof typeof statusEn]
 
 // 책 담기 상태 한국어
 export const statusKo = {
-    read: '읽은 책',
-    reading: '읽고 있는 책',
-    wish: '읽고 싶은 책',
+    READ: '읽은 책',
+    READING: '읽고 있는 책',
+    WISH: '읽고 싶은 책',
 }

--- a/src/types/libraryType.ts
+++ b/src/types/libraryType.ts
@@ -19,7 +19,6 @@ export interface LibraryDetailType {
     endDate: string | null
     page: number | null
     expectation: string | null
-    recordList: RecordType[]
 }
 
 // 기록 데이터 타입
@@ -29,4 +28,6 @@ export interface RecordType {
     tag: Tag
     date: string
     content: string
+    createdAt: string
+    updatedAt: string
 }

--- a/src/types/libraryType.ts
+++ b/src/types/libraryType.ts
@@ -22,6 +22,11 @@ export interface LibraryDetailType {
 }
 
 // 기록 데이터 타입
+export interface RecordListType {
+    totalPages: number
+    currentPage: number
+    recordList: RecordType[]
+}
 export interface RecordType {
     recordId: number
     page: number | null


### PR DESCRIPTION
### 변경사항
- 담은 책 정보 보여주기 & 오류 수정(읽은 책 정보 key 추가)
- 기록 목록 보여주기
- 서재 상세 담은 책 정보 태그("읽은 책", "읽고 싶은 책", "읽고 있는 책") 안 보이는 오류 수정
- 담은 책 상태(read, reading, wish) 타입을 대문자로 수정
  - 백엔드 데이터와 통일하기 위해서 대문자로 수정함
- 기록 타입 수정
  - 기록 목록이 담은 책 정보(LibraryDetailType)에 있었는데, 기록 목록 타입(RecordListType)을 따로 만듦

close #29 