### PR TITLE
#35 서재 수정하기

### DIFF
--- a/src/components/ReadBook.tsx
+++ b/src/components/ReadBook.tsx
@@ -9,29 +9,20 @@ export default function ReadBook({
     readInfo: ReadInfoType
     setReadInfo: React.Dispatch<React.SetStateAction<ReadInfoType>>
 }) {
-    // FIXME 효율적이지 않은 코드 같음. 하드코딩 아닌 방식으로 구현
-    const [starScore, setStarScore] = useState<number>()
-    const [starArr, setStarArr] = useState<number[]>([1, 1, 1, 0, 0])
-    const handleClickStarScore = (value: number) => {
-        switch (value) {
-            case 0:
-                setStarArr([1, 0, 0, 0, 0])
-                break
-            case 1:
-                setStarArr([1, 1, 0, 0, 0])
-                break
-            case 2:
-                setStarArr([1, 1, 1, 0, 0])
-                break
-            case 3:
-                setStarArr([1, 1, 1, 1, 0])
-                break
-            case 4:
-                setStarArr([1, 1, 1, 1, 1])
-                break
-            default:
-                setStarArr([1, 1, 1, 1, 1])
+    const getStarArr = (starScore: number): number[] => {
+        const arr = new Array(5).fill(0)
+        for (let i = 0; i < starScore; i += 1) {
+            arr[i] = 1
         }
+        return arr
+    }
+    // FIXME 효율적이지 않은 코드 같음. 하드코딩 아닌 방식으로 구현
+    const [starArr, setStarArr] = useState<number[]>(
+        getStarArr(readInfo.starScore ?? 0)
+    )
+    const handleClickStarScore = (index: number) => {
+        const updatedStarArr = starArr.map((star, i) => (i <= index ? 1 : 0))
+        setStarArr(updatedStarArr)
     }
 
     useEffect(() => {
@@ -40,10 +31,6 @@ export default function ReadBook({
             count += num === 1 ? 1 : 0
         })
 
-        console.log(count)
-        console.log(starScore)
-
-        setStarScore(count)
         setReadInfo((prevValue) => ({ ...prevValue, starScore: count }))
     }, [starArr])
 

--- a/src/components/WishBook.tsx
+++ b/src/components/WishBook.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import { WishInfoType } from './AddBookModal'
 
-type Props = {
+export default function WishBook({
+    wishInfo,
+    setWishInfo,
+}: {
+    wishInfo: WishInfoType
     setWishInfo: React.Dispatch<React.SetStateAction<WishInfoType>>
-}
-export default function WishBook({ setWishInfo }: Props) {
+}) {
     const handleChageExpectation = (
         e: React.ChangeEvent<HTMLTextAreaElement>
     ) => {
@@ -17,6 +20,7 @@ export default function WishBook({ setWishInfo }: Props) {
                 className="resize-none p-4 border-gray border-[0.5px] rounded-md"
                 rows={7}
                 placeholder="책을 알게 된 경로, 기대되는 점 등을 기록해보세요"
+                value={wishInfo.expectation ?? ''}
                 onChange={handleChageExpectation}
             />
         </div>

--- a/src/pages/LibraryDetail.tsx
+++ b/src/pages/LibraryDetail.tsx
@@ -21,12 +21,16 @@ import {
 } from '../services/library'
 import { LibraryDetailType, RecordListType } from '../types/libraryType'
 import RecordingModal from '../components/RecordingModal'
+import UpdateBookModal from '../components/UpdateBookModal'
 
 export default function LibraryDetail() {
     const { isbn } = useParams()
     const [searchDocument, setSearchDocument] = useState<searchDocumentType>()
     const [recordPage, setRecordPage] = useState<number>(1)
-    const [isOpenModal, setIsOpenModal] = useState<boolean>(false)
+    const [isOpenRecordingModal, setIsOpenRecordingModal] =
+        useState<boolean>(false)
+    const [isOpenUpdateBookModal, setIsOpenUpdateBookModal] =
+        useState<boolean>(false)
 
     useEffect(() => {
         if (isbn !== undefined) {
@@ -75,7 +79,15 @@ export default function LibraryDetail() {
 
     return (
         <div>
-            {isOpenModal && <RecordingModal setIsOpenModal={setIsOpenModal} />}
+            {isOpenRecordingModal && (
+                <RecordingModal setIsOpenModal={setIsOpenRecordingModal} />
+            )}
+            {isOpenUpdateBookModal && (
+                <UpdateBookModal
+                    setIsOpenModal={setIsOpenUpdateBookModal}
+                    isbn={isbn ?? ''}
+                />
+            )}
             <Header />
             <Wrapper>
                 <div className="flex justify-between mb-6">
@@ -97,6 +109,7 @@ export default function LibraryDetail() {
                             <button
                                 type="button"
                                 className="text-gray underline"
+                                onClick={() => setIsOpenUpdateBookModal(true)}
                             >
                                 수정
                             </button>
@@ -144,7 +157,7 @@ export default function LibraryDetail() {
                         <button
                             type="button"
                             className="underline"
-                            onClick={() => setIsOpenModal(true)}
+                            onClick={() => setIsOpenRecordingModal(true)}
                         >
                             기록 추가하기
                         </button>

--- a/src/services/library.ts
+++ b/src/services/library.ts
@@ -24,6 +24,17 @@ export const getLibrary = async (
     return response.data.results
 }
 
+export const getIsInTheLibrary = async (isbn: string) => {
+    const response = await axios.get<responseType<LibraryDetailType>>(
+        `${process.env.REACT_APP_API}/api/library`,
+        {
+            params: isbn,
+        }
+    )
+
+    return response.data
+}
+
 export const getLibraryDetail = async (
     isbn: string
 ): Promise<LibraryDetailType> => {

--- a/src/services/library.ts
+++ b/src/services/library.ts
@@ -24,17 +24,6 @@ export const getLibrary = async (
     return response.data.results
 }
 
-export const getIsInTheLibrary = async (isbn: string) => {
-    const response = await axios.get<responseType<LibraryDetailType>>(
-        `${process.env.REACT_APP_API}/api/library`,
-        {
-            params: isbn,
-        }
-    )
-
-    return response.data
-}
-
 export const getLibraryDetail = async (
     isbn: string
 ): Promise<LibraryDetailType> => {
@@ -129,6 +118,44 @@ export const postLibrary = async ({
         return null
     }
     const response = await axios.post(
+        `${process.env.REACT_APP_API}/api/library`,
+        {
+            isbn,
+            status: status.toUpperCase(),
+            startDate,
+            finishDate,
+            readingPages,
+            rate,
+            expactation: expectation,
+        }
+    )
+
+    return response
+}
+
+export const putLibrary = async ({
+    isbn,
+    status,
+    startDate,
+    finishDate,
+    readingPages,
+    rate,
+    expectation,
+}: {
+    isbn: string
+    status: Status
+    startDate: string | null
+    finishDate: string | null
+    readingPages: number | null
+    rate: number | null
+    expectation: string | null
+}) => {
+    if (isbn === null || isbn.trim().length === 0) {
+        console.log('isbn 없음!!!')
+
+        return null
+    }
+    const response = await axios.put(
         `${process.env.REACT_APP_API}/api/library`,
         {
             isbn,


### PR DESCRIPTION
### 변경사항
- 담은 책 수정하기 모달 추가(기존의 책 담기 모달(AddBookModal)과 분리하기로 함)
  - 구현이 어렵고 오히려 코드가 복잡해져서 일단 중복 코드가 많지만 모달을 분리했습니다.
- 담은 책 수정하기 api 요청 함수 추가
- 읽은 책 별점 렌더링 코드 리팩토링(선언적으로)

### 주의사항
- 담은 책의 별점 초깃값이 비동기적으로 받아오는 값이기 때문에 반영이 좀 늦습니다. 해당 부분은 차차 수정하도록 하겠습니다

close #35